### PR TITLE
Adds a prop for inverted rendering of list data

### DIFF
--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -225,6 +225,11 @@ var ListView = React.createClass({
      * If empty sections are not desired to be rendered their indices should be excluded from sectionID object.
      */
     enableEmptySections: PropTypes.bool,
+    
+    /**
+    * Flag indicating whether data source should be read in inverted order.
+    */
+    inverted: PropTypes.bool,
   },
 
   /**
@@ -421,7 +426,8 @@ var ListView = React.createClass({
         }
       }
 
-      for (var rowIdx = 0; rowIdx < rowIDs.length; rowIdx++) {
+      for (var _rowIdx = 0; _rowIdx < rowIDs.length; _rowIdx++) {
+        var rowIdx = this.props.inverted?rowIDs.length - 1 - _rowIdx:_rowIdx;
         var rowID = rowIDs[rowIdx];
         var comboID = sectionID + '_' + rowID;
         var shouldUpdateRow = rowCount >= this._prevRenderedRowsCount &&


### PR DESCRIPTION
The 'inverted' prop causes the listview to render the data in inverse order.

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?

Rendering the items in the listview in reverse order allows efficient prepending functionality without re-rendering the whole listview. See:

https://github.com/facebook/react-native/issues/1682
https://github.com/facebook/react-native/issues/2219
https://github.com/facebook/react-native/issues/107

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests
